### PR TITLE
.travis.yml: explicit COVERALLS_TOKEN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 go:
   - 1.7.4
   - tip
+env:
+  - COVERALLS_TOKEN=1DndLGOn2URLtVJyuVXFSNKU3Jd8n8mE0
 install:
   - go get -v github.com/golang/lint/golint
   - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
Travis stopped setting env vars defined in the repo settings for PR branches, claiming a security issue. It's a real pain in the ass for things like Coveralls. To the best of my knowledge, the only way around it is to explicitly set the token in the .travis.yml.