### PR TITLE
Ensure random part is always read from the entropy reader in full

### DIFF
--- a/ulid.go
+++ b/ulid.go
@@ -79,7 +79,7 @@ func New(ms uint64, entropy io.Reader) (id ULID, err error) {
 	}
 
 	if entropy != nil {
-		_, err = entropy.Read(id[6:])
+		_, err = io.ReadFull(entropy, id[6:])
 	}
 
 	return id, err


### PR DESCRIPTION
With regards to https://github.com/satori/go.uuid/issues/73, we should make sure ULID's random part is always fully read from its entropy source.