### PR TITLE
Use underlying entropy source for random increments in Monotonic

### DIFF
--- a/ulid.go
+++ b/ulid.go
@@ -581,8 +581,6 @@ func (m *monotonic) random() (inc uint64, err error) {
 		case 5, 6, 7, 8:
 			inc = uint64(binary.LittleEndian.Uint64(m.rand[:8]))
 		}
-
-		// println(inc, " < ", m.inc, " == ", inc < m.inc)
 	}
 
 	fmt.Printf("inc: %d, max: %d, bitLen: %d, byteLen: %d, msbitLen: %d\n",

--- a/ulid.go
+++ b/ulid.go
@@ -19,7 +19,6 @@ import (
 	"database/sql/driver"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"math"
 	"math/bits"
@@ -582,9 +581,6 @@ func (m *monotonic) random() (inc uint64, err error) {
 			inc = uint64(binary.LittleEndian.Uint64(m.rand[:8]))
 		}
 	}
-
-	fmt.Printf("inc: %d, max: %d, bitLen: %d, byteLen: %d, msbitLen: %d\n",
-		inc, m.inc, bitLen, byteLen, msbitLen)
 
 	// Range: [1, m.inc)
 	return 1 + inc, nil

--- a/ulid.go
+++ b/ulid.go
@@ -535,7 +535,7 @@ func (m *monotonic) increment() error {
 }
 
 // random returns a uniform random value in [1, m.inc), reading entropy
-// from m.Reader When m.inc == 0 || m.inc == 1, it returns 1.
+// from m.Reader. When m.inc == 0 || m.inc == 1, it returns 1.
 // Adapted from: https://golang.org/pkg/crypto/rand/#Int
 func (m *monotonic) random() (inc uint64, err error) {
 	if m.inc <= 1 {

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -547,7 +547,14 @@ func TestMonotonic(t *testing.T) {
 func TestMonotonicOverflow(t *testing.T) {
 	t.Parallel()
 
-	entropy := ulid.Monotonic(bytes.NewReader(bytes.Repeat([]byte{0xFF}, 10)), 0)
+	entropy := ulid.Monotonic(
+		io.MultiReader(
+			bytes.NewReader(bytes.Repeat([]byte{0xFF}, 10)), // Entropy for first ULID
+			crand.Reader, // Following random entropy
+		),
+		0,
+	)
+
 	prev, err := ulid.New(0, entropy)
 	if err != nil {
 		t.Fatal(err)

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -596,6 +596,8 @@ func benchmarkMakeULID(b *testing.B, f func(uint64, io.Reader)) {
 		{"WithMonotonicEntropy_DifferentTimestamp_Inc0", []uint64{122, 123}, ulid.Monotonic(rng, 0)},
 		{"WithMonotonicEntropy_SameTimestamp_Inc1", []uint64{123}, ulid.Monotonic(rng, 1)},
 		{"WithMonotonicEntropy_DifferentTimestamp_Inc1", []uint64{122, 123}, ulid.Monotonic(rng, 1)},
+		{"WithCryptoMonotonicEntropy_SameTimestamp_Inc1", []uint64{123}, ulid.Monotonic(crand.Reader, 1)},
+		{"WithCryptoMonotonicEntropy_DifferentTimestamp_Inc1", []uint64{122, 123}, ulid.Monotonic(crand.Reader, 1)},
 		{"WithoutEntropy", []uint64{123}, nil},
 	} {
 		tc := tc

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -523,7 +523,14 @@ func TestMonotonic(t *testing.T) {
 		{"cryptorand", func() io.Reader { return crand.Reader }},
 		{"mathrand", func() io.Reader { return rand.New(rand.NewSource(int64(now))) }},
 	} {
-		for _, inc := range []uint64{0, 1, math.MaxUint8 + 1, math.MaxUint16 + 1} {
+		for _, inc := range []uint64{
+			0,
+			1,
+			2,
+			math.MaxUint8 + 1,
+			math.MaxUint16 + 1,
+			math.MaxUint32 + 1,
+		} {
 			inc := inc
 			entropy := ulid.Monotonic(e.mk(), uint64(inc))
 


### PR DESCRIPTION
This commit makes the random increments on `Monotonic` reads to always
be computed using bytes read from the underlying entropy source, whereas
before they'd be always derived from a `rand.Reader`.

In the process, I've refactored the benchmarks to be more dry using a table driven test approach. While this had the desired effect, it also affected the benchmark numbers slightly.

So here's a `benchstat` output of the comparison of the new and old code, but with old benchmark test code still.

```
name                                                old time/op   new time/op   delta
New/WithMonotonicEntropy_SameTimestamp_Inc0-8        73.4ns ± 1%   83.6ns ± 2%  +13.89%  (p=0.000 n=10+10)
New/WithMonotonicEntropy_DifferentTimestamp_Inc0-8   82.4ns ± 2%   82.7ns ± 2%     ~     (p=0.424 n=10+10)
New/WithMonotonicEntropy_SameTimestamp_Inc1-8        42.4ns ± 1%   45.2ns ± 3%   +6.72%  (p=0.000 n=10+10)
New/WithMonotonicEntropy_DifferentTimestamp_Inc1-8   83.3ns ± 1%   84.3ns ± 4%     ~     (p=0.175 n=9+10)

name                                                old speed     new speed     delta
New/WithMonotonicEntropy_SameTimestamp_Inc0-8       218MB/s ± 1%  192MB/s ± 1%  -12.04%  (p=0.000 n=10+9)
New/WithMonotonicEntropy_DifferentTimestamp_Inc0-8  194MB/s ± 2%  194MB/s ± 2%     ~     (p=0.436 n=10+10)
New/WithMonotonicEntropy_SameTimestamp_Inc1-8       378MB/s ± 1%  354MB/s ± 3%   -6.27%  (p=0.000 n=10+10)
New/WithMonotonicEntropy_DifferentTimestamp_Inc1-8  192MB/s ± 1%  190MB/s ± 4%     ~     (p=0.190 n=10+10)
```

I think this is acceptable, but please let me know if you see opportunities for optimisation.