### PR TITLE
cmd/ulid: use Time helper instead of parsing manually

### DIFF
--- a/cmd/ulid/main.go
+++ b/cmd/ulid/main.go
@@ -89,13 +89,7 @@ func parse(s string, local bool, f func(time.Time) string) {
 		os.Exit(1)
 	}
 
-	var (
-		msec = id.Time()
-		sec  = msec / 1e3
-		rem  = msec % 1e3
-		nsec = rem * 1e6
-		t    = time.Unix(int64(sec), int64(nsec))
-	)
+	t := ulid.Time(id.Time())
 	if !local {
 		t = t.UTC()
 	}


### PR DESCRIPTION
The code in cmd/ulid/ulid.go pre-dates the ulid.Time helper method, I think.