### PR TITLE
TestMonotonicSafe fails sometimes

### DIFF
--- a/ulid_test.go
+++ b/ulid_test.go
@@ -585,45 +585,19 @@ func TestMonotonicOverflow(t *testing.T) {
 func TestMonotonicSafe(t *testing.T) {
 	t.Parallel()
 
-	for _, seed := range []int64{
-		0,
-		1,
-		12,
-		123,
-		1234,
-		12345,
-		123456,
-		1234567,
-		12345678,
-		123456789,
-		time.Now().UnixNano(),
-	} {
-		for _, inc := range []uint64{
-			0,
-			1e1,
-			1e2,
-			1e3,
-			1e4,
-			1e6,
-			1e6,
-		} {
-			t.Run(fmt.Sprintf("seed=%d_inc=%d", seed, inc), func(t *testing.T) {
-				var (
-					src       = rand.NewSource(seed)
-					entropy   = rand.New(src)
-					monotonic = ulid.Monotonic(entropy, inc)
-					safe      = &safeMonotonicReader{MonotonicReader: monotonic}
-				)
+	var (
+		src       = rand.NewSource(time.Now().UnixNano())
+		entropy   = rand.New(src)
+		monotonic = ulid.Monotonic(entropy, 0)
+		safe      = &safeMonotonicReader{MonotonicReader: monotonic}
+	)
 
-				t0 := time.Now()
-				u0 := ulid.MustNew(ulid.Timestamp(t0), safe)
-				u1 := ulid.MustNew(ulid.Timestamp(t0), safe)
+	t0 := time.Now()
+	u0 := ulid.MustNew(ulid.Timestamp(t0), safe)
+	u1 := ulid.MustNew(ulid.Timestamp(t0), safe)
 
-				if u0.String() >= u1.String() {
-					t.Fatalf("%s (time %d entropy %x) >= %s (time %d entropy %x)", u0.String(), u0.Time(), u0.Entropy(), u1.String(), u1.Time(), u1.Entropy())
-				}
-			})
-		}
+	if u0.String() >= u1.String() {
+		t.Fatalf("%s (time %d entropy %x) >= %s (time %d entropy %x)", u0.String(), u0.Time(), u0.Entropy(), u1.String(), u1.Time(), u1.Entropy())
 	}
 }
 


### PR DESCRIPTION
ulid.Monotonic is not goroutine-safe, so I want to protect it with a mutex via e.g. `safeReader`. However, when I do that, it no longer reliably produces monotonically-increasing entropy. Here is the test output on my machine.

```
$ go test -count 10 -run TestMonotonicSafe
--- FAIL: TestMonotonicSafe (0.00s)
    ulid_test.go:599: 01D7JB3BSKDWJJQM6K907K8ZMR (time 1554320043827 entropy 6f252bd0d3480f347e98) >= 01D7JB3BSK480NQ77QR5VBMEV9 (time 1554320043827 entropy 22015b9cf7c176ba3b69)
--- FAIL: TestMonotonicSafe (0.00s)
    ulid_test.go:599: 01D7JB3BSKRBDYR7RJ3JXGBQA6 (time 1554320043827 entropy c2dbec1f121cbb05dd46) >= 01D7JB3BSKCZV1CK492PVYBR30 (time 1554320043827 entropy 67f6164c8915b7e5e060)
--- FAIL: TestMonotonicSafe (0.00s)
    ulid_test.go:599: 01D7JB3BSMWMHW4CR5HTZMXMAX (time 1554320043828 entropy e523c233058ebf4ed15d) >= 01D7JB3BSMKK2ZND39ZCMTSRG1 (time 1554320043828 entropy 9cc5fab469fb29ace201)
--- FAIL: TestMonotonicSafe (0.00s)
    ulid_test.go:599: 01D7JB3BSMYB78B3ZMVNJ1X2NS (time 1554320043828 entropy f2ce858ff4dd641e8ab9) >= 01D7JB3BSMXW5PV5M1G5XK279Y (time 1554320043828 entropy ef0b6d9681817b311d3e)
--- FAIL: TestMonotonicSafe (0.00s)
    ulid_test.go:599: 01D7JB3BSMQJHBF38XFHR9HY1Q (time 1554320043828 entropy bca2b78d1d7c7098f837) >= 01D7JB3BSM5MWQPN17VF676BTP (time 1554320043828 entropy 2d397b5427dbcc732f56)
FAIL
exit status 1
FAIL	github.com/oklog/ulid	0.005s
```