### PR TITLE
Add /v2 suffix to import

### DIFF
--- a/ulid_test.go
+++ b/ulid_test.go
@@ -27,7 +27,7 @@ import (
 	"testing/quick"
 	"time"
 
-	"github.com/oklog/ulid"
+	"github.com/oklog/ulid/v2"
 )
 
 func ExampleULID() {


### PR DESCRIPTION
If we opt-in to modules with a non-v0 or v1 version, we have to explicitly append /vX to the import path whenever we import. This is infuriating, but I guess I lost that battle.