### PR TITLE
Update README to mention v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Universally Unique Lexicographically Sortable Identifier
 
-![Project status](https://img.shields.io/badge/version-2.0.2-yellow.svg)
+[![Project status](https://img.shields.io/github/release/oklog/ulid.svg?style=flat-square)](https://github.com/oklog/ulid/releases/latest)
 [![Build Status](https://secure.travis-ci.org/oklog/ulid.png)](http://travis-ci.org/oklog/ulid)
 [![Go Report Card](https://goreportcard.com/badge/oklog/ulid?cache=0)](https://goreportcard.com/report/oklog/ulid)
 [![Coverage Status](https://coveralls.io/repos/github/oklog/ulid/badge.svg?branch=master&cache=0)](https://coveralls.io/github/oklog/ulid?branch=master)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Universally Unique Lexicographically Sortable Identifier
 
-![Project status](https://img.shields.io/badge/version-1.3.0-yellow.svg)
+![Project status](https://img.shields.io/badge/version-2.0.2-yellow.svg)
 [![Build Status](https://secure.travis-ci.org/oklog/ulid.png)](http://travis-ci.org/oklog/ulid)
 [![Go Report Card](https://goreportcard.com/badge/oklog/ulid?cache=0)](https://goreportcard.com/report/oklog/ulid)
 [![Coverage Status](https://coveralls.io/repos/github/oklog/ulid/badge.svg?branch=master&cache=0)](https://coveralls.io/github/oklog/ulid?branch=master)
@@ -32,7 +32,7 @@ A ULID however:
 ## Install
 
 ```shell
-go get github.com/oklog/ulid
+go get github.com/oklog/ulid/v2
 ```
 
 ## Usage


### PR DESCRIPTION
Was having a problem trying to get a `*MonotonicEntropy` from `Monotonic()`, before I realized it was in v2 (while I had the old 1.3 installed).

Might want to add a bigger notice about using v2 instead?