### PR TITLE
Continuous fuzzing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
+dist: bionic
 language: go
 sudo: false
+services:
+  - docker
 env:
-  GO111MODULE=on
+  global:
+    - GO111MODULE=on
+    # FUZZIT_API_KEY
+    - secure: "FEm1wF/Ttd5RIvDPg5I/aSAhBWuvkvjmkInFxlVKP4BfLsR1B1ogXV4zKFQiZugyppBta+qP4qP+tSbThSvP9JOCr+/ivnTyYLg/DH1RfQnC7rJmAaZwHGHB+NwblRzU621uIZ4RVvaE391YVJf5519gc+M+bxZ6DO0ScdpbIAVV/7JR9c7Tuvoyi57/MEwAS39k7h83ms8JgRYwuvzpVH9nb6AfYs+CzXuRlsG5mHqFnmzLyG0ewnqh18OoWbyKQwBmM+EoIGmckM8NQZaXWBhEuDP7qdl+QatNfZtK3YwBx2plahBXXMee3NpOAEHOkWxNw1uMb1B8ILDrzrx8oX1A4fF/ZeJl7JLZS/fQUMhDnLG5soA0xaEoAvwhQIHFi3e207rsq9UJsnQlRGhRWzMvx85UR5z+yiur8nVUkogu1DGpH/BPdWbTs+d8behSr7t6Sepo7enjJOPJLz6U67JlP31HvnaLICMEXxJy54BAbdu/47vqFp15lcIMHyDzPltHHWi6uGuRFQPYz8pM5ZAKQ945dO/ZELyEHbjUiLTMFeVoANzahuY56BX6hvsygcOlBWB6ukoJANvxgvM/QYkbh9dMBajYsZqHCWOKRVbBakkqPAUqkBNPOADTp5ZgUwmRySIGzX2X+Efl7cFYZVu+IJl968F8hqYajvS/VCs="
 go:
   - 1.10.x
   - 1.11.x
@@ -18,3 +24,15 @@ script:
   - go test -v -race ./...
   - go test -v -covermode=count -coverprofile=cov.out
   - $HOME/gopath/bin/goveralls -coverprofile=cov.out -service=travis-ci -repotoken "$COVERALLS_TOKEN" || true
+jobs:
+  include:
+    - stage: Fuzz regression
+      go: 1.12.x
+      script:
+        - ./fuzzit.sh local-regression
+
+    - stage: Fuzz
+      if: branch = master AND type IN (push)
+      go: 1.12.x
+      script:
+        - ./fuzzit.sh fuzzing

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/oklog/ulid/badge.svg?branch=master&cache=0)](https://coveralls.io/github/oklog/ulid?branch=master)
 [![GoDoc](https://godoc.org/github.com/oklog/ulid?status.svg)](https://godoc.org/github.com/oklog/ulid)
 [![Apache 2 licensed](https://img.shields.io/badge/license-Apache2-blue.svg)](https://raw.githubusercontent.com/oklog/ulid/master/LICENSE)
+[![fuzzit](https://app.fuzzit.dev/badge?org_id=oklog)](https://app.fuzzit.dev/orgs/oklog/dashboard)
 
 A Go port of [alizain/ulid](https://github.com/alizain/ulid) with binary format implemented.
 

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -xe
+
+NAME=ulid
+TYPE=$1
+
+function fuzz {
+    TARGET=$NAME-$1
+    FUNCTION=Fuzz$2
+    go-fuzz-build -libfuzzer -func $FUNCTION -o $NAME.a .
+    clang -fsanitize=fuzzer $NAME.a -o $NAME
+    ./fuzzit create job --type $TYPE $TARGET $NAME
+}
+
+# Setup
+export GO111MODULE="off"
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+go get -d -v -u ./...
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+# Fuzz
+fuzz new New
+fuzz parse Parse
+fuzz parse-strict ParseStrict

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,25 +1,36 @@
 #!/bin/bash
 set -xe
 
-NAME=ulid
-TYPE=$1
+# Validate arguments
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <fuzz-type>"
+    exit 1
+fi
 
-function fuzz {
-    TARGET=$NAME-$1
-    FUNCTION=Fuzz$2
-    go-fuzz-build -libfuzzer -func $FUNCTION -o $NAME.a .
-    clang -fsanitize=fuzzer $NAME.a -o $NAME
-    ./fuzzit create job --type $TYPE $TARGET $NAME
-}
+# Configure
+NAME=ulid
+ROOT=.
+TYPE=$1
 
 # Setup
 export GO111MODULE="off"
 go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
 go get -d -v -u ./...
-wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
-chmod a+x fuzzit
+if [ ! -f fuzzit ]; then
+    wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
+    chmod a+x fuzzit
+fi
 
 # Fuzz
-fuzz new New
-fuzz parse Parse
-fuzz parse-strict ParseStrict
+function fuzz {
+    FUNC=Fuzz$1
+    TARGET=$2
+    DIR=${3:-$ROOT}
+    go-fuzz-build -libfuzzer -func $FUNC -o fuzzer.a $DIR
+    clang -fsanitize=fuzzer fuzzer.a -o fuzzer
+    ./fuzzit create job --type $TYPE $NAME/$TARGET fuzzer
+}
+fuzz New new
+fuzz NewMonotonic new-monotonic
+fuzz Parse parse
+fuzz ParseStrict parse-strict

--- a/ulid_fuzz.go
+++ b/ulid_fuzz.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 )
 
+// FuzzNew tests ULID construction with fuzzed timestamp and entropy.
 func FuzzNew(input []byte) int {
 	var ms uint64
 	binary.Read(bytes.NewReader(input), binary.LittleEndian, &ms)
@@ -32,6 +33,7 @@ func FuzzNew(input []byte) int {
 	return 1
 }
 
+// FuzzParse tests ULID parsing.
 func FuzzParse(input []byte) int {
 	id, err := Parse(string(input))
 	if err != nil {
@@ -51,6 +53,7 @@ func FuzzParse(input []byte) int {
 	return 1
 }
 
+// FuzzParse tests strict ULID parsing.
 func FuzzParseStrict(input []byte) int {
 	id, err := ParseStrict(string(input))
 	if err != nil {

--- a/ulid_fuzz.go
+++ b/ulid_fuzz.go
@@ -7,14 +7,9 @@ import (
 	"encoding/binary"
 )
 
-// FuzzNew tests ULID construction with fuzzed timestamp and entropy.
+// FuzzNew tests ULID construction.
 func FuzzNew(fuzz []byte) int {
-	var ms uint64
-	binary.Read(bytes.NewReader(fuzz), binary.LittleEndian, &ms)
-	var entropy []byte
-	if len(fuzz) > 8 {
-		entropy = fuzz[7:]
-	}
+	ms, entropy := extractFuzzTimestamp(fuzz)
 	id, err := New(ms, bytes.NewReader(entropy))
 	if err != nil {
 		return 0
@@ -29,6 +24,41 @@ func FuzzNew(fuzz []byte) int {
 	_, err = id.MarshalBinary()
 	if err != nil {
 		return 0
+	}
+	return 1
+}
+
+// FuzzNewMonotonic tests ULID construction with monotonic entropy.
+func FuzzNewMonotonic(fuzz []byte) int {
+	if len(fuzz) < (8 * 10) {
+		return -1
+	}
+	timestamps := fuzz[0 : 8*10]
+	var entropy []byte
+	if len(fuzz) > (8 * 10) {
+		entropy = fuzz[8*10:]
+	} else {
+		entropy = []byte{}
+	}
+	monotonic := Monotonic(bytes.NewReader(entropy), 0)
+	var ms uint64
+	for range [10]struct{}{} {
+		ms, timestamps = extractFuzzTimestamp(timestamps)
+		id, err := New(ms, monotonic)
+		if err != nil {
+			return 0
+		}
+		id.Bytes()
+		id.Entropy()
+		id.Time()
+		_, err = id.MarshalText()
+		if err != nil {
+			return 0
+		}
+		_, err = id.MarshalBinary()
+		if err != nil {
+			return 0
+		}
 	}
 	return 1
 }
@@ -71,4 +101,14 @@ func FuzzParseStrict(fuzz []byte) int {
 		return 0
 	}
 	return 1
+}
+
+func extractFuzzTimestamp(fuzz []byte) (ms uint64, rest []byte) {
+	binary.Read(bytes.NewReader(fuzz), binary.LittleEndian, &ms)
+	if len(fuzz) > 8 {
+		rest = fuzz[7:]
+	} else {
+		rest = []byte{}
+	}
+	return
 }

--- a/ulid_fuzz.go
+++ b/ulid_fuzz.go
@@ -8,12 +8,12 @@ import (
 )
 
 // FuzzNew tests ULID construction with fuzzed timestamp and entropy.
-func FuzzNew(input []byte) int {
+func FuzzNew(fuzz []byte) int {
 	var ms uint64
-	binary.Read(bytes.NewReader(input), binary.LittleEndian, &ms)
+	binary.Read(bytes.NewReader(fuzz), binary.LittleEndian, &ms)
 	var entropy []byte
-	if len(input) > 8 {
-		entropy = input[7:]
+	if len(fuzz) > 8 {
+		entropy = fuzz[7:]
 	}
 	id, err := New(ms, bytes.NewReader(entropy))
 	if err != nil {
@@ -34,8 +34,8 @@ func FuzzNew(input []byte) int {
 }
 
 // FuzzParse tests ULID parsing.
-func FuzzParse(input []byte) int {
-	id, err := Parse(string(input))
+func FuzzParse(fuzz []byte) int {
+	id, err := Parse(string(fuzz))
 	if err != nil {
 		return 0
 	}
@@ -54,8 +54,8 @@ func FuzzParse(input []byte) int {
 }
 
 // FuzzParse tests strict ULID parsing.
-func FuzzParseStrict(input []byte) int {
-	id, err := ParseStrict(string(input))
+func FuzzParseStrict(fuzz []byte) int {
+	id, err := ParseStrict(string(fuzz))
 	if err != nil {
 		return 0
 	}

--- a/ulid_fuzz.go
+++ b/ulid_fuzz.go
@@ -1,0 +1,71 @@
+// +build gofuzz
+
+package ulid
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+func FuzzNew(input []byte) int {
+	var ms uint64
+	binary.Read(bytes.NewReader(input), binary.LittleEndian, &ms)
+	var entropy []byte
+	if len(input) > 8 {
+		entropy = input[7:]
+	}
+	id, err := New(ms, bytes.NewReader(entropy))
+	if err != nil {
+		return 0
+	}
+	id.Bytes()
+	id.Entropy()
+	id.Time()
+	_, err = id.MarshalText()
+	if err != nil {
+		return 0
+	}
+	_, err = id.MarshalBinary()
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
+func FuzzParse(input []byte) int {
+	id, err := Parse(string(input))
+	if err != nil {
+		return 0
+	}
+	id.Bytes()
+	id.Entropy()
+	id.Time()
+	_, err = id.MarshalText()
+	if err != nil {
+		return 0
+	}
+	_, err = id.MarshalBinary()
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
+func FuzzParseStrict(input []byte) int {
+	id, err := ParseStrict(string(input))
+	if err != nil {
+		return 0
+	}
+	id.Bytes()
+	id.Entropy()
+	id.Time()
+	_, err = id.MarshalText()
+	if err != nil {
+		return 0
+	}
+	_, err = id.MarshalBinary()
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
Proposing to integrate continuous fuzzing. Fuzzit gives free service for open source projects.

This targets `Parse` and `ParseStrict` by input + `New` by fuzzing the timestamp and entropy.

Setup is like this:
* In [Fuzzit](https://fuzzit.dev/) create targets `ulid-new` `ulid-parse` `ulid-parse-strict`.
* In Fuzzit settings grab an API key. On the repo settings in [Travis](https://travis-ci.org/) paste it to envvar `FUZZIT_API_KEY`.

Thanks for considering.

@peterbourgon @tsenart