### PR TITLE
README: remove /v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A ULID however:
 ## Install
 
 ```shell
-go get github.com/oklog/ulid/v2
+go get github.com/oklog/ulid
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This repo also provides a tool to generate and parse ULIDs at the command line.
 Installation:
 
 ```shell
-go get github.com/oklog/ulid/cmd/ulid
+env GO111MODULE=on go get github.com/oklog/ulid/cmd/ulid/v2
 ```
 
 Usage:


### PR DESCRIPTION
The install command didn't work for me without removing the `/v2`.