### PR TITLE
Fix max theorical date in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Below is the current specification of ULID as implemented in this repository.
 **Timestamp**
 - 48 bits
 - UNIX-time in milliseconds
-- Won't run out of space till the year 10895 AD
+- Won't run out of space till the year 10889 AD
 
 **Entropy**
 - 80 bits


### PR DESCRIPTION
From what I understood in my tests and in https://github.com/oklog/ulid/issues/9, the max possible base32 timestamp is `7ZZZZZZZZZ`. Consequently, the current max year in the README is wrong.