### PR TITLE
Refer updated github link of `alizain/ulid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/oklog/ulid/v2)
 [![Apache 2 licensed](https://img.shields.io/badge/license-Apache2-blue.svg)](https://raw.githubusercontent.com/oklog/ulid/master/LICENSE)
 
-A Go port of [alizain/ulid](https://github.com/alizain/ulid) with binary format implemented.
+A Go port of [ulid/javascript](https://github.com/ulid/javascript) with binary format implemented.
 
 ## Background
 
@@ -179,6 +179,6 @@ BenchmarkCompare-8                    200000000     7.34 ns/op    4359.23 MB/s  
 
 ## Prior Art
 
-- [alizain/ulid](https://github.com/alizain/ulid)
+- [ulid/javascript](https://github.com/ulid/javascript)
 - [RobThree/NUlid](https://github.com/RobThree/NUlid)
 - [imdario/go-ulid](https://github.com/imdario/go-ulid)


### PR DESCRIPTION
Why
---

```
~/r/g/ulid ❯❯❯ curl https://github.com/alizain/ulid                                               update-origin-link
<html><body>You are being <a href="https://github.com/ulid/javascript">redirected</a>.</body></html>%
```

So looks changed the repository to https://github.com/ulid/javascript

Note
---

I didn't change test name 😄 

https://github.com/oklog/ulid/blob/c6bb9e1d94a82e71dfd7ff279aa6cea7c52779bb/ulid_test.go#L204

