### PR TITLE
Fix timezone formatting in RFC 3339 output

### DIFF
--- a/cmd/ulid/main.go
+++ b/cmd/ulid/main.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultms = "Mon Jan 02 15:04:05.999 MST 2006"
-	rfc3339ms = "2006-01-02T15:04:05.999Z07:00"
+	rfc3339ms = "2006-01-02T15:04:05.000Z07:00"
 )
 
 func main() {

--- a/cmd/ulid/main.go
+++ b/cmd/ulid/main.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultms = "Mon Jan 02 15:04:05.999 MST 2006"
-	rfc3339ms = "2006-01-02T15:04:05.999MST"
+	rfc3339ms = "2006-01-02T15:04:05.999Z07:00"
 )
 
 func main() {


### PR DESCRIPTION
UTC or other time zone names or abbreviations are not valid there, need
to have Z or [-+]hh:mm.