### PR TITLE
Add fmt, vet, staticcheck to CI and lint accordingly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,14 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Go
         uses: actions/setup-go@v3
+      - name: fmt
+        run: test -z (gofmt -l .)
+      - name: vet
+        run: go vet ./...
+      - name: staticcheck
+        uses: dominikh/staticcheck-action@v1.2.0
         with:
-          go-version-file: "./go.mod"
-      - name: Lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest
+          install-go: false
 
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
       - name: fmt
-        run: test -z (gofmt -l .)
+        run: test -z $(gofmt -l .)
       - name: vet
         run: go vet ./...
       - name: staticcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,20 @@
 on: [push, pull_request]
 name: Test
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "./go.mod"
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+
   test:
     strategy:
       matrix:
@@ -9,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
     - name: Check out code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v3
       - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version-file: "./go.mod"
-      - name: Check out code
-        uses: actions/checkout@v3
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/ulid.go
+++ b/ulid.go
@@ -28,7 +28,7 @@ import (
 )
 
 /*
-An ULID is a 16 byte Universally Unique Lexicographically Sortable Identifier
+A ULID is a 16 byte Universally Unique Lexicographically Sortable Identifier
 
 	The components are encoded as 16 octets.
 	Each component is encoded with the MSB first (network byte order).
@@ -60,7 +60,7 @@ var (
 	// size.
 	ErrBufferSize = errors.New("ulid: bad buffer size when marshaling")
 
-	// ErrBigTime is returned when constructing an ULID with a time that is larger
+	// ErrBigTime is returned when constructing a ULID with a time that is larger
 	// than MaxTime.
 	ErrBigTime = errors.New("ulid: time too big")
 
@@ -86,7 +86,7 @@ type MonotonicReader interface {
 	MonotonicRead(ms uint64, p []byte) error
 }
 
-// New returns an ULID with the given Unix milliseconds timestamp and an
+// New returns a ULID with the given Unix milliseconds timestamp and an
 // optional entropy source. Use the Timestamp function to convert
 // a time.Time to Unix milliseconds.
 //
@@ -139,7 +139,7 @@ func DefaultEntropy() io.Reader {
 	return entropy
 }
 
-// Make returns an ULID with the current time in Unix milliseconds and
+// Make returns a ULID with the current time in Unix milliseconds and
 // monotonically increasing entropy for the same millisecond.
 // It is safe for concurrent use, leveraging a sync.Pool underneath for minimal
 // contention.
@@ -294,7 +294,7 @@ func (id ULID) MarshalBinaryTo(dst []byte) error {
 }
 
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler interface by
-// copying the passed data and converting it to an ULID. ErrDataSize is
+// copying the passed data and converting it to a ULID. ErrDataSize is
 // returned if the data length is different from ULID length.
 func (id *ULID) UnmarshalBinary(data []byte) error {
 	if len(data) != len(*id) {
@@ -411,11 +411,11 @@ func (id ULID) Time() uint64 {
 }
 
 // maxTime is the maximum Unix time in milliseconds that can be
-// represented in an ULID.
+// represented in a ULID.
 var maxTime = ULID{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}.Time()
 
 // MaxTime returns the maximum Unix time in milliseconds that
-// can be encoded in an ULID.
+// can be encoded in a ULID.
 func MaxTime() uint64 { return maxTime }
 
 // Now is a convenience function that returns the current

--- a/ulid.go
+++ b/ulid.go
@@ -420,7 +420,8 @@ func MaxTime() uint64 { return maxTime }
 
 // Now is a convenience function that returns the current
 // UTC time in Unix milliseconds. Equivalent to:
-//   Timestamp(time.Now().UTC())
+//
+//	Timestamp(time.Now().UTC())
 func Now() uint64 { return Timestamp(time.Now().UTC()) }
 
 // Timestamp converts a time.Time to Unix milliseconds.
@@ -501,33 +502,32 @@ func (id *ULID) Scan(src interface{}) error {
 // representation instead, you can create a wrapper type that calls String()
 // instead.
 //
-//    type stringValuer ulid.ULID
+//	type stringValuer ulid.ULID
 //
-//    func (v stringValuer) Value() (driver.Value, error) {
-//        return ulid.ULID(v).String(), nil
-//    }
+//	func (v stringValuer) Value() (driver.Value, error) {
+//	    return ulid.ULID(v).String(), nil
+//	}
 //
-//    // Example usage.
-//    db.Exec("...", stringValuer(id))
+//	// Example usage.
+//	db.Exec("...", stringValuer(id))
 //
 // All valid ULIDs, including zero-value ULIDs, return a valid Value with a nil
 // error. If your use case requires zero-value ULIDs to return a non-nil error,
 // you can create a wrapper type that special-cases this behavior.
 //
-//    var zeroValueULID ulid.ULID
+//	var zeroValueULID ulid.ULID
 //
-//    type invalidZeroValuer ulid.ULID
+//	type invalidZeroValuer ulid.ULID
 //
-//    func (v invalidZeroValuer) Value() (driver.Value, error) {
-//        if ulid.ULID(v).Compare(zeroValueULID) == 0 {
-//            return nil, fmt.Errorf("zero value")
-//        }
-//        return ulid.ULID(v).Value()
-//    }
+//	func (v invalidZeroValuer) Value() (driver.Value, error) {
+//	    if ulid.ULID(v).Compare(zeroValueULID) == 0 {
+//	        return nil, fmt.Errorf("zero value")
+//	    }
+//	    return ulid.ULID(v).Value()
+//	}
 //
-//    // Example usage.
-//    db.Exec("...", invalidZeroValuer(id))
-//
+//	// Example usage.
+//	db.Exec("...", invalidZeroValuer(id))
 func (id ULID) Value() (driver.Value, error) {
 	return id.MarshalBinary()
 }

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -605,7 +605,7 @@ func TestMonotonicSafe(t *testing.T) {
 	for i := 0; i < cap(errs); i++ {
 		go func() {
 			u0 := ulid.MustNew(t0, safe)
-			u1 := ulid.MustNew(t0, safe)
+			u1 := u0
 			for j := 0; j < 1024; j++ {
 				u0, u1 = u1, ulid.MustNew(t0, safe)
 				if u0.String() >= u1.String() {

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -604,10 +604,9 @@ func TestMonotonicSafe(t *testing.T) {
 	errs := make(chan error, 100)
 	for i := 0; i < cap(errs); i++ {
 		go func() {
-			u0 := ulid.MustNew(t0, safe)
 			u1 := ulid.MustNew(t0, safe)
 			for j := 0; j < 1024; j++ {
-				u0, u1 = u1, ulid.MustNew(t0, safe)
+				u0, u1 := u1, ulid.MustNew(t0, safe)
 				if u0.String() >= u1.String() {
 					errs <- fmt.Errorf(
 						"%s (%d %x) >= %s (%d %x)",

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -604,9 +604,10 @@ func TestMonotonicSafe(t *testing.T) {
 	errs := make(chan error, 100)
 	for i := 0; i < cap(errs); i++ {
 		go func() {
+			u0 := ulid.MustNew(t0, safe)
 			u1 := ulid.MustNew(t0, safe)
 			for j := 0; j < 1024; j++ {
-				u0, u1 := u1, ulid.MustNew(t0, safe)
+				u0, u1 = u1, ulid.MustNew(t0, safe)
 				if u0.String() >= u1.String() {
 					errs <- fmt.Errorf(
 						"%s (%d %x) >= %s (%d %x)",


### PR DESCRIPTION
Fix some small typos in the comments. 

By the way, it also seems that `ulid.go` is not properly gofmted. For example, when I run it I get a bunch of stuff that looks like
```
-//    // Example usage.
-//    db.Exec("...", stringValuer(id))
+//	// Example usage.
+//	db.Exec("...", stringValuer(id))
```
in the diff. Would you like me to push those changes in this PR?