### PR TITLE
Add function `MakeString`

### DIFF
--- a/ulid.go
+++ b/ulid.go
@@ -155,6 +155,11 @@ func Make() (id ULID) {
 	return MustNew(Now(), DefaultEntropy())
 }
 
+// MakeString is a convenience function equivalent to Make().String().
+func MakeString() string {
+	return Make().String()
+}
+
 // Parse parses an encoded ULID, returning an error in case of failure.
 //
 // ErrDataSize is returned if the len(ulid) is different from an encoded

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -72,6 +72,18 @@ func TestMake(t *testing.T) {
 	}
 }
 
+func TestMakeString(t *testing.T) {
+	t.Parallel()
+	id := ulid.MakeString()
+	rt, err := ulid.Parse(id)
+	if err != nil {
+		t.Fatalf("parse %q: %v", id, err)
+	}
+	if id != rt.String() {
+		t.Fatalf("%q != %q", id, rt.String())
+	}
+}
+
 func TestMustNew(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR adds function `MakeString` - simple wrapper of `Make().String()`.