### PR TITLE
refactor(timestamp): remove redundant `.UTC()` call and mentions

### DIFF
--- a/ulid.go
+++ b/ulid.go
@@ -427,8 +427,8 @@ func MaxTime() uint64 { return maxTime }
 // Now is a convenience function that returns the current
 // UTC time in Unix milliseconds. Equivalent to:
 //
-//	Timestamp(time.Now().UTC())
-func Now() uint64 { return Timestamp(time.Now().UTC()) }
+//	Timestamp(time.Now())
+func Now() uint64 { return Timestamp(time.Now()) }
 
 // Timestamp converts a time.Time to Unix milliseconds.
 //

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -834,10 +834,21 @@ func BenchmarkNow(b *testing.B) {
 
 func BenchmarkTimestamp(b *testing.B) {
 	now := time.Now()
-	b.SetBytes(8)
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = ulid.Timestamp(now)
+	for _, tc := range []struct {
+		name   string
+		tsfunc func() time.Time
+	}{
+		{"WithLocal", func() time.Time { return now }},
+		{"WithUTC", func() time.Time { return now.UTC() }}, //nolint:gocritic // keep lambda for fair comparison
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			b.SetBytes(8)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = ulid.Timestamp(tc.tsfunc())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Unix timestamps are always from UTC epoch, and calculation from given `time.Time` is independent of its location.