### PR TITLE
Add `ulid.Nil` and `.IsZero()` method

### DIFF
--- a/ulid.go
+++ b/ulid.go
@@ -76,8 +76,8 @@ var (
 	// into the ULID.
 	ErrScanValue = errors.New("ulid: source value must be a string or byte slice")
 
-	// Nil is an empty ULID, all zeros, useful when comparing nil ULIDs
-	Nil ULID
+	// Zero is a zero-value ULID.
+	Zero ULID
 )
 
 // MonotonicReader is an interface that should yield monotonically increasing

--- a/ulid.go
+++ b/ulid.go
@@ -75,6 +75,9 @@ var (
 	// ErrScanValue is returned when the value passed to scan cannot be unmarshaled
 	// into the ULID.
 	ErrScanValue = errors.New("ulid: source value must be a string or byte slice")
+
+	// Nil is an empty ULID, all zeros, useful when comparing nil ULIDs
+	Nil ULID
 )
 
 // MonotonicReader is an interface that should yield monotonically increasing
@@ -414,6 +417,11 @@ func (id ULID) Time() uint64 {
 // Timestamp returns the time encoded in the ULID as a time.Time.
 func (id ULID) Timestamp() time.Time {
 	return Time(id.Time())
+}
+
+// IsZero returns whether the ULID is a zero-value, ie ulid.Nil.
+func (id ULID) IsZero() bool {
+	return bytes.Equal(id[:], Nil[:])
 }
 
 // maxTime is the maximum Unix time in milliseconds that can be

--- a/ulid.go
+++ b/ulid.go
@@ -421,7 +421,7 @@ func (id ULID) Timestamp() time.Time {
 
 // IsZero returns true if the ULID is a zero-value ULID, i.e. ulid.Zero.
 func (id ULID) IsZero() bool {
-	return bytes.Equal(id[:], Nil[:])
+	return id.Compare(Zero) == 0
 }
 
 // maxTime is the maximum Unix time in milliseconds that can be

--- a/ulid.go
+++ b/ulid.go
@@ -419,7 +419,7 @@ func (id ULID) Timestamp() time.Time {
 	return Time(id.Time())
 }
 
-// IsZero returns whether the ULID is a zero-value, ie ulid.Nil.
+// IsZero returns true if the ULID is a zero-value ULID, i.e. ulid.Zero.
 func (id ULID) IsZero() bool {
 	return bytes.Equal(id[:], Nil[:])
 }

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -459,7 +459,7 @@ func TestZero(t *testing.T) {
 
 	var id ulid.ULID
 	if ok := id.IsZero(); !ok {
-		t.Error(".IsZero: must return true for empty ULIDs, have false")
+		t.Error(".IsZero: must return true for zero-value ULIDs, have false")
 	}
 
 	id = ulid.MustNew(ulid.Now(), ulid.DefaultEntropy())

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -464,7 +464,7 @@ func TestZero(t *testing.T) {
 
 	id = ulid.MustNew(ulid.Now(), ulid.DefaultEntropy())
 	if ok := id.IsZero(); ok {
-		t.Error(".IsZero: must return false for non-nil ULIDs, have true")
+		t.Error(".IsZero: must return false for non-zero-value ULIDs, have true")
 	}
 }
 

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -454,6 +454,20 @@ func TestULIDTimestamp(t *testing.T) {
 	}
 }
 
+func TestZero(t *testing.T) {
+	t.Parallel()
+
+	var id ulid.ULID
+	if ok := id.IsZero(); !ok {
+		t.Error(".IsZero: must return true for empty ULIDs, have false")
+	}
+
+	id = ulid.MustNew(ulid.Now(), ulid.DefaultEntropy())
+	if ok := id.IsZero(); ok {
+		t.Error(".IsZero: must return false for non-nil ULIDs, have true")
+	}
+}
+
 func TestEntropy(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This simplifies comparisons with empty ULIDs.  Right now, most people are doing something like the following to check if a ULID is non-zero:

```go
id.Compare(ulid.ULID{}) == 0
```

This requires allocating a new empty ULID each time.  Some packages avoid this by creating their own global (or private) nil ULIDs on initialization.

This should be built in and simple for better perf & a cleaner API.