### PR TITLE
fix: handle sql scan postgres string

### DIFF
--- a/ulid.go
+++ b/ulid.go
@@ -497,6 +497,12 @@ func (id *ULID) Scan(src interface{}) error {
 	case string:
 		return id.UnmarshalText([]byte(x))
 	case []byte:
+		// copied from: https://github.com/google/uuid/blob/6e10cd1027e225e3ad7bfcc13c896abd165b02ef/sql.go#L40-L44
+		// assumes a simple slice of bytes if 16 bytes
+		// otherwise attempts to parse
+		if len(x) != 16 {
+			return id.UnmarshalText(x)
+		}
 		return id.UnmarshalBinary(x)
 	}
 

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -554,6 +554,7 @@ func TestScan(t *testing.T) {
 		{"bytes", id[:], id, nil},
 		{"nil", nil, ulid.ULID{}, nil},
 		{"other", 44, ulid.ULID{}, ulid.ErrScanValue},
+		{"string_in_bytes", []byte(id.String()), id, nil},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
postgres provides string value in bytes

reference: https://github.com/google/uuid/blob/6e10cd1027e225e3ad7bfcc13c896abd165b02ef/sql.go#L40-L44