### PR TITLE
Use ParseStrict to be invalided ILOU characters #69

### DIFF
--- a/cmd/ulid/main.go
+++ b/cmd/ulid/main.go
@@ -83,7 +83,7 @@ func generate(quick, zero bool) {
 }
 
 func parse(s string, local bool, f func(time.Time) string) {
-	id, err := ulid.Parse(s)
+	id, err := ulid.ParseStrict(s)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Fix #69 

The rust ulid crate has no #69 ‘s issue below, that is why our golang's library should same condition for command to use ulid.ParseStrict by default.

crates: https://docs.rs/ulid/latest/ulid/
test code: 
```
% cat ./src/main.rs 
use ulid::Ulid;

fn main() {
    let result1 = Ulid::from_string("0LLLLLLLLLLLLLLLLLLLLLLLLL");
    let result2 = Ulid::from_string("01111111111111111111111111");
    assert_eq!(result1, result2);
}
```
result
```
% ./target/debug/ulid-test
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `Err(InvalidChar)`,
 right: `Ok(Ulid(1372106318229590578481349223515194401))`', src/main.rs:6:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```