### PR TITLE
Migrate default entropy to rand/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ performance, cryptographic security, etc., use the
 [ulid.Make](https://pkg.go.dev/github.com/oklog/ulid/v2#Make) helper function.
 This function calls [time.Now](https://pkg.go.dev/time#Now) to get a timestamp,
 and uses a source of entropy which is process-global,
-[pseudo-random](https://pkg.go.dev/math/rand), and
+[pseudo-random](https://pkg.go.dev/math/rand/v2), and
 [monotonic](https://pkg.go.dev/github.com/oklog/ulid/v2#LockedMonotonicReader).
 
 ```go
@@ -69,7 +69,11 @@ More advanced use cases should utilize
 [ulid.New](https://pkg.go.dev/github.com/oklog/ulid/v2#New).
 
 ```go
-entropy := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+seed := [32]byte{}
+binary.LittleEndian.PutUint64(seed[:8], uint64(time.Now().UnixNano()))
+entropy := rand.NewChaCha8(seed) // This uses math/rand/v2.
+
 ms := ulid.Timestamp(time.Now())
 fmt.Println(ulid.New(ms, entropy))
 // 01G65Z755AFWAKHE12NY0CQ9FH
@@ -77,7 +81,7 @@ fmt.Println(ulid.New(ms, entropy))
 
 Care should be taken when providing a source of entropy.
 
-The above example utilizes [math/rand.Rand](https://pkg.go.dev/math/rand#Rand),
+The above example utilizes [math/rand/v2.Rand](https://pkg.go.dev/math/rand/v2#Rand),
 which is not safe for concurrent use by multiple goroutines. Consider
 alternatives such as
 [x/exp/rand](https://pkg.go.dev/golang.org/x/exp/rand#LockedSource).

--- a/cmd/ulid/main.go
+++ b/cmd/ulid/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	cryptorand "crypto/rand"
+	"encoding/binary"
 	"fmt"
-	mathrand "math/rand"
+	mathrand "math/rand/v2"
 	"os"
 	"strings"
 	"time"
@@ -65,9 +66,9 @@ func main() {
 func generate(quick, zero bool) {
 	entropy := cryptorand.Reader
 	if quick {
-		seed := time.Now().UnixNano()
-		source := mathrand.NewSource(seed)
-		entropy = mathrand.New(source)
+		seed := [32]byte{}
+		binary.LittleEndian.PutUint64(seed[:8], uint64(time.Now().UnixNano()))
+		entropy = mathrand.NewChaCha8(seed)
 	}
 	if zero {
 		entropy = zeroReader{}

--- a/ulid.go
+++ b/ulid.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"math"
 	"math/bits"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 )
@@ -133,7 +133,9 @@ func MustNewDefault(t time.Time) ULID {
 }
 
 var defaultEntropy = func() io.Reader {
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	seed := [32]byte{}
+	binary.LittleEndian.PutUint64(seed[:8], uint64(time.Now().UnixNano()))
+	rng := rand.NewChaCha8(seed)
 	return &LockedMonotonicReader{MonotonicReader: Monotonic(rng, 0)}
 }()
 


### PR DESCRIPTION
As discussed a bit in #123  it is looking like it is worth migrating to rand/v2 and advising people to use this in the README as well.

@peterbourgon and myself had both run some benchmarks and it does seem it is ever so slightly faster in most cases and somewhat slower (±6ns) in one of the benchmarks.

This PR changes the examples, tests and benchmarks to use math/rand/v2 instead of math.rand.
I use a chacha8 source which is the only one in there that implements an io.Reader.

The difference with randV1.NewSource is that it requires a [32]byte seed instead of a uint64. For this I currently just put the time in nanoseconds as the first 8 bytes and leave the rest empty.

I've also updated the README examples suggesting the usage of math/rand/v2 instead of math/rand.

Below are some benchmark results on my machine, I deliberately did not yet update these in the README.md as I'm not sure if you wanted to keep that as the same machine you had them on previously.

[benchmark.txt](https://github.com/user-attachments/files/19044873/benchmark.txt)

Let me know if you have any questions or require any further changes.
