### PR TITLE
Optimize ULID Compare performance

### DIFF
--- a/ulid.go
+++ b/ulid.go
@@ -24,7 +24,6 @@ import (
 	"math/rand"
 	"sync"
 	"time"
-	"unsafe"
 )
 
 /*
@@ -493,10 +492,10 @@ func (id *ULID) SetEntropy(e []byte) error {
 // Compare returns an integer comparing id and other lexicographically.
 // The result will be 0 if id==other, -1 if id < other, and +1 if id > other.
 func (id ULID) Compare(other ULID) int {
-	ih := *(*uint64)(unsafe.Pointer(&id[0]))
-	il := *(*uint64)(unsafe.Pointer(&id[8]))
-	oh := *(*uint64)(unsafe.Pointer(&other[0]))
-	ol := *(*uint64)(unsafe.Pointer(&other[8]))
+	ih := binary.NativeEndian.Uint64(id[0:8])
+	il := binary.NativeEndian.Uint64(id[8:16])
+	oh := binary.NativeEndian.Uint64(other[0:8])
+	ol := binary.NativeEndian.Uint64(other[8:16])
 	if ih > oh {
 		return 1
 	}

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -892,7 +892,20 @@ func BenchmarkSetEntropy(b *testing.B) {
 	}
 }
 
-func BenchmarkCompare(b *testing.B) {
+func OldCompare(id, other ulid.ULID) int {
+	return bytes.Compare(id[:], other[:])
+}
+
+func BenchmarkOldCompare(b *testing.B) {
+	id, other := ulid.MustNew(12345, nil), ulid.MustNew(54321, nil)
+	b.SetBytes(int64(len(id) * 2))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = OldCompare(id, other)
+	}
+}
+
+func BenchmarkNewCompare(b *testing.B) {
 	id, other := ulid.MustNew(12345, nil), ulid.MustNew(54321, nil)
 	b.SetBytes(int64(len(id) * 2))
 	b.ResetTimer()


### PR DESCRIPTION
ULID can be seen as two uint64 types. The previous comparison method performed multiple meaningless operations (such as checking if the lengths are equal). The new method addresses these issues; please refer to the benchmark tests for specifics.

Old:
```
cpu: AMD Ryzen 9 4900H with Radeon Graphics
=== RUN   BenchmarkOld
BenchmarkOld
BenchmarkOld-16
346184070                3.469 ns/op    9225.41 MB/s           0 B/op          0 allocs/op
PASS
```

New:
```
cpu: AMD Ryzen 9 4900H with Radeon Graphics
=== RUN   BenchmarkNew
BenchmarkNew
BenchmarkNew-16
604745437                1.975 ns/op    16203.47 MB/s          0 B/op          0 allocs/op
PASS
```