### PR TITLE
fix: Scan accepts text-encoded ULIDs in []byte

### DIFF
--- a/ulid.go
+++ b/ulid.go
@@ -505,7 +505,16 @@ func (id *ULID) Scan(src interface{}) error {
 	case string:
 		return id.UnmarshalText([]byte(x))
 	case []byte:
-		return id.UnmarshalBinary(x)
+		// Drivers often return text/varchar columns as []byte. Accept both
+		// the 16-byte binary form and the 26-character text encoding.
+		switch len(x) {
+		case len(*id):
+			return id.UnmarshalBinary(x)
+		case EncodedSize:
+			return id.UnmarshalText(x)
+		default:
+			return ErrDataSize
+		}
 	}
 
 	return ErrScanValue

--- a/ulid_test.go
+++ b/ulid_test.go
@@ -566,6 +566,7 @@ func TestScan(t *testing.T) {
 	}{
 		{"string", id.String(), id, nil},
 		{"bytes", id[:], id, nil},
+		{"text-as-bytes", []byte(id.String()), id, nil},
 		{"nil", nil, ulid.ULID{}, nil},
 		{"other", 44, ulid.ULID{}, ulid.ErrScanValue},
 	} {


### PR DESCRIPTION
## Summary

`(*ULID).Scan` treated every `[]byte` as binary. Drivers commonly hand text columns back as `[]byte`, so scanning a 26-character encoded ULID failed with `ErrDataSize`.

Accept both lengths:
- 16 → binary
- 26 → text encoding

## Test plan

- [x] `go test -run TestScan` (includes `text-as-bytes` case)